### PR TITLE
♻️ refactor : topic이랑 연계되게끔 코드를 수정. topic의 타입 지정을 명확하게 수정. 💄style : 검색창 내부 버튼의 위치 지정을 다시

### DIFF
--- a/src/app/search/_components/DetailedSearchBar.tsx
+++ b/src/app/search/_components/DetailedSearchBar.tsx
@@ -16,6 +16,8 @@ const DetailedSearchBar = ({
   selectedCategory,
   setSelectedCategory,
 }: DetailedSearchBarProps) => {
+    console.log(category)
+    console.log(categoryMapping)
   return (
     <>
       <div className="flex flex-row items-center gap-2">
@@ -47,13 +49,13 @@ const DetailedSearchBar = ({
                     prev === category ? null : category,
                   )
                 }
-                className={`w-16 h-10 mx-1 rounded-full border ${
+                className={`w-14 h-10 mx-1 rounded-full border ${
                   selectedCategory === category
                     ? 'bg-black text-white'
                     : 'bg-gray-200'
                 }`}
               >
-                <span className="text-s">{categoryMapping[category]}</span>
+                <span className="text-xs">{category}</span>
               </button>
             ))}
           </div>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -62,22 +62,24 @@ const SearchPage = () => {
         <Link href="/">
           <IoIosArrowBack size={30} />
         </Link>
-        <input
-          {...register('searchQuery')}
-          type="text"
-          placeholder="검색어를 입력해주세요"
-          className="border border-black rounded-full h-8 w-72 mt-1 mb-1 px-4"
-        />
-        <button
-          type="button"
-          className="absolute right-14 top-2"
-          onClick={() => setValue('searchQuery', '')}
-        >
-          <IoMdCloseCircle size={25} />
-        </button>
-        <Link href="/">
-          <span className="mr-1">닫기</span>
-        </Link>
+        <div className='flex flex-row justify-center items-center relative'>
+          <input
+            {...register('searchQuery')}
+            type="text"
+            placeholder="검색어를 입력해주세요"
+            className="border border-black rounded-full h-8 w-72 mt-1 mb-1 px-4"
+          />
+          <button
+            type="button"
+            className="absolute right-11"
+            onClick={() => setValue('searchQuery', '')}
+          >
+            <IoMdCloseCircle size={25} />
+          </button>
+          <Link href="/">
+            <span className="ml-2">닫기</span>
+          </Link>
+        </div>
       </form>
       <div className="inner">
         <div className="flex flex-col">

--- a/src/data/category.ts
+++ b/src/data/category.ts
@@ -1,3 +1,5 @@
+import { EnglishCategory, KoreanCategory, topicMapping } from '@/utils/topics';
+
 export type Category =
   | 'all'
   | 'food'
@@ -6,20 +8,12 @@ export type Category =
   | 'event'
   | 'date-price';
 
-export const category: Category[] = [
-  'all',
-  'food',
-  'place',
-  'shelter',
-  'event',
-  'date-price',
-];
+export const category = ['전체', ...Object.keys(topicMapping)];
 
-export const categoryMapping: Record<Category, string> = {
-  all: '전체',
-  food: '음식',
-  place: '장소',
-  shelter: '숙소',
-  event: '이벤트',
-  'date-price': '경비',
+export const categoryMapping: Record<
+  KoreanCategory | '전체',
+  EnglishCategory | 'all'
+> = {
+  전체: 'all',
+  ...topicMapping,
 };

--- a/src/utils/topics.ts
+++ b/src/utils/topics.ts
@@ -1,5 +1,28 @@
 // 주제 한국어-영어 매핑
-export const topicMapping: { [key: string]: string } = {
+export type EnglishCategory =
+  | 'food'
+  | 'shopping'
+  | 'lodging'
+  | 'event'
+  | 'date-price'
+  | 'schedule-expenses'
+  | 'culture'
+  | 'history'
+  | 'activity'
+  | 'etc';
+
+export type KoreanCategory =
+  | '맛집'
+  | '쇼핑'
+  | '숙소'
+  | '이벤트'
+  | '일정/경비'
+  | '문화'
+  | '역사'
+  | '액티비티'
+  | '기타';
+
+export const topicMapping: Record<KoreanCategory, EnglishCategory> = {
   맛집: 'food',
   쇼핑: 'shopping',
   숙소: 'lodging',
@@ -12,12 +35,12 @@ export const topicMapping: { [key: string]: string } = {
 };
 
 // 주제를 영어로 변환하는 유틸 함수
-export const convertTopicsToEnglish = (topics: string[]): string[] => {
+export const convertTopicsToEnglish = (topics: KoreanCategory[]): string[] => {
   return topics.map((topic) => topicMapping[topic] || topic);
 };
 
 // 영어에서 한국어로
-export const convertTopicsToKorean = (topics: string[]): string[] => {
+export const convertTopicsToKorean = (topics: EnglishCategory[]): string[] => {
   const reverseMapping = Object.fromEntries(
     Object.entries(topicMapping).map(([kor, eng]) => [eng, kor]),
   );


### PR DESCRIPTION
## What is this PR

- topic 데이터를 최대한 활용하는 방향으로 코드를 다시 짰습니다. 

## Changes

- topic의 타입지정을 다시 했습니다. 홈페이지에서 돌려본 결과, 타입지정 변화로 인한 버그는 일단 없었습니다. 
- 왜 이렇게 했느냐고 한다면, 와프 상에선 전체, all 타입이 있었기 때문이었습니다. 해당 항목을 추가해서 맵핑을 해야했기 때문에, 제가 쓰던 기본 데이터를 쓰는 게 최선이라 생각하여 topic에서 끌어오는 식으로 리팩토링을 했는데, 이 과정에서 타입지정을 다시 상세하게 할 수밖에 없었습니다. 

## CheckList

-topic의 타입 지정으로 인한 버그 이슈가 없는 지 체크 부탁드립니다. 

