### PR TITLE
🩹fix:기존의 getUser를 사용하던 방식을 session을 이용한 방식으로 수정

### DIFF
--- a/src/app/mypage/_components/CategoryTabs.tsx
+++ b/src/app/mypage/_components/CategoryTabs.tsx
@@ -6,7 +6,7 @@ import { supabase } from '@/utils/supabase/supabaseClient';
 
 type Props = {
   activeTab: 'written' | 'response' | 'bookmark';
-  onUpdateCounts?: () => void; // 카운트를 업데이트하는 콜백 함수
+  onUpdateCounts?: () => void; 
 };
 
 const CategoryTabs = ({ activeTab, onUpdateCounts }: Props) => {
@@ -26,7 +26,7 @@ const CategoryTabs = ({ activeTab, onUpdateCounts }: Props) => {
         return;
       }
 
-      const userId = userData.user.id; // 사용자 ID
+      const userId = userData.user.id;
 
       // 작성글 개수 가져오기
       const { count: writtenCount } = await supabase

--- a/src/app/mypage/seller-auth/page.tsx
+++ b/src/app/mypage/seller-auth/page.tsx
@@ -70,7 +70,7 @@ const SellerPage = () => {
               {/* 완료 상태 박스 */}
               {isIdentityVerified && (
                 <div
-                  className="flex items-center justify-center px-2 py-1 gap-2 text-white text-sm font-medium rounded"
+                  className="flex items-center justify-center px-1.5 py-0.5 gap-1 text-white text-xs font-medium rounded"
                   style={{
                     background: '#575757',
                     borderRadius: '4px',


### PR DESCRIPTION
## What is this PR

-기존의 getUser를 사용하던 방식이 오류가 나서 session을 이용한 방식으로 수정

## Changes

- 기존의 getUser를 사용하던 방식을 session을 이용한 방식으로 수정
- 로그인 상태 확인 후, 세션 데이터를 통해 사용자 프로필 정보를 불러오도록 변경
- 프로필 이미지 업로드 기능에서 오류 처리 추가
- 프로필 저장 시, 이미지를 업로드하고 URL을 제대로 가져오는지 확인하도록 수정

## CheckList

-

## Issue Number

- (샵 입력 후, 원하는 이슈를 tab으로 선택.)
