### PR TITLE
✨ feat: fetchuser 전역으로 실행

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -13,6 +13,7 @@ import { topicMapping } from '@/utils/topics';
 import { usePosts } from '@/utils/api/tanstack/home/usePosts';
 import { useBookmarkMutations } from '@/utils/api/tanstack/home/BookmarkHooks';
 import { useBookmarks } from '@/utils/api/tanstack/home/useBookmark';
+import { useUserStore } from '@/store/userStore';
 
 const CategoryPage = () => {
   //서치파람스의 값으로 카테고리 1차구분
@@ -28,7 +29,8 @@ const CategoryPage = () => {
 
   //로그인한 유저
   const userId = '0fdbd37c-1b2e-4142-b50b-e593f13487a7';
-
+  const { user } = useUserStore();
+  console.log(user);
   //북마크
   const { addBookmarkMutation, deleteBookmarkMutation } =
     useBookmarkMutations(userId);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,15 +25,16 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  
   return (
     <html lang="en">
       <body
       // className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <div className="bg-container">
-          <Header />
-          <Providers>{children}</Providers>
+          <Providers>
+            <Header />
+            {children}
+          </Providers>
         </div>
       </body>
     </html>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import TanstackQueryProvider from '@/providers/TanstackQueryProvider';
-import {
-  QueryClientProvider,
-} from '@tanstack/react-query';
+import { useUserStore } from '@/store/userStore';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useEffect } from 'react';
 
 type Props = {
   children: React.ReactNode;
@@ -12,6 +12,12 @@ type Props = {
 
 const Providers = ({ children }: Props) => {
   const { queryClient } = TanstackQueryProvider();
+  const { fetchUser } = useUserStore();
+
+  useEffect(() => {
+    fetchUser();
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <ReactQueryDevtools initialIsOpen={false} />

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,0 +1,77 @@
+'use client';
+
+import { Tables } from '@/types/supabase';
+import { createClient } from '@/utils/supabase/client';
+import { User } from '@supabase/supabase-js';
+import { create } from 'zustand';
+
+type UserState = {
+  user: User | null;
+  userTable: Tables<'users'> | null;
+  isLogin: boolean;
+  fetchUser: () => Promise<void>;
+};
+
+export const useUserStore = create<UserState>((set) => ({
+  user: null,
+  userTable: null,
+  isLogin: false,
+
+  fetchUser: async () => {
+    const supabase = createClient();
+    const { data: userData, error: userDataError } =
+      await supabase.auth.getUser();
+
+    if (userDataError || !userData.user) {
+      return;
+    }
+
+    if (userData) {
+      set({
+        user: userData.user,
+        isLogin: true,
+      });
+    } else {
+      set({
+        user: null,
+        userTable: null,
+        isLogin: false,
+      });
+    }
+  },
+
+  fetchUserData: async (userId: string): Promise<void> => {
+    const supabase = createClient();
+
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .select('*')
+        .eq('id', userId)
+        .single();
+
+      if (error) {
+        console.error('사용자 데이터 가져오기 오류:', error);
+        return;
+      }
+
+      if (data) {
+        const userData: Tables<'users'> = {
+          id: data.id,
+          authenticated: data.authenticated,
+          country: data.country,
+          created_at: data.created_at,
+          credit: data.credit,
+          email: data.email,
+          introduction: data.introduction,
+          nickname: data.nickname,
+          profile_img: data.profile_img,
+        };
+
+        set({ userTable: userData, isLogin: true });
+      }
+    } catch (err) {
+      console.error('사용자 데이터 가져오기 오류:', err);
+    }
+  },
+}));

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,5 +1,4 @@
-
-import { Database } from '@/app/common/types/supabase';
+import { Database } from '@/types/supabase';
 import { createBrowserClient } from '@supabase/ssr';
 
 export const createClient = () => {


### PR DESCRIPTION
## What is this PR

-✨ feat: fetchuser 전역으로 실행

## Changes

- userstore의 유저데이터 실행 함수를 레이아웃 상단 프로바이더스에서 실행하여, 모든 컴포넌트(client) 에서 유저를 가져올수 있게 하였음

## CheckList

- 기존 getuser 함수는 user 데이터를 리턴하여, 새로 작성하였는데, 이부분 나중에 통일해도 될듯
