### PR TITLE
🚑 fix : 검색에서 게시물의 2줄로 끊겨서 보이지 않는 문제 해결

### DIFF
--- a/src/app/search/[id]/_components/RequestDetail.tsx
+++ b/src/app/search/[id]/_components/RequestDetail.tsx
@@ -97,10 +97,10 @@ const RequestDetail = ({
         <div className="flex flex-row items-start">
           <p className="text-[16px] font-[600] pt-[1px] text-[#0582FF]">Q.</p>
           <div>
-            <p className="max-w-[315px] text-[16px] font-[600] ml-[6px] mb-[6px] overflow-hidden text-ellipsis">
+            <p className="max-w-[315px] text-[16px] font-[600] ml-[6px] mb-[6px] overflow-hidden text-ellipsis line-clamp-2">
               {post.title}
             </p>
-            <p className="text-[14px] max-w-[295px] text-[#797C80] font-[500] ml-[6px] overflow-hidden text-ellipsis">
+            <p className="text-[14px] max-w-[315px] text-[#797C80] font-[500] ml-[6px] overflow-hidden text-ellipsis line-clamp-2">
               {post.content}
             </p>
           </div>

--- a/src/app/search/[id]/_components/ResponseContent.tsx
+++ b/src/app/search/[id]/_components/ResponseContent.tsx
@@ -6,6 +6,6 @@ const stripHtmlTags = (html: string | undefined) => {
 
 const ResponseContent = ({ html }: { html: string | undefined }) => {
   const textContent = stripHtmlTags(html);
-  return <p className="text-[14px] max-w-[295px] text-[#797C80] font-[500] ml-[6px] overflow-hidden text-ellipsis">{textContent}</p>;
+  return <p className="text-[14px] max-w-[315px] text-[#797C80] font-[500] ml-[6px] overflow-hidden text-ellipsis line-clamp-2">{textContent}</p>;
 };
 export default ResponseContent;


### PR DESCRIPTION
## What is this PR

- 🚑 fix : 검색에서 게시물의 2줄로 끊겨서 보이지 않는 문제 해결

## Changes

- 두 줄로 끊겨서 보이는데 게시물 내용 전체가 보이는 문제가 있었습니다. 그걸 다시 테스트 중 발견하여 해결하였습니다. 
